### PR TITLE
Fixes a typo at aspnetcore/grpc/authn-and-authz.md

### DIFF
--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -30,7 +30,7 @@ public void Configure(IApplicationBuilder app)
 
     app.UseEndpoints(endpoints =>
     {
-        routes.MapGrpcService<GreeterService>();
+        endpoints.MapGrpcService<GreeterService>();
     });
 }
 ```


### PR DESCRIPTION
Fixes a typo at  the example of `Startup.Configure`
~~routes~~endpoints